### PR TITLE
Restore the wait function of the ssram and fpga_comm libraries

### DIFF
--- a/include/ice/fpga_comm.h
+++ b/include/ice/fpga_comm.h
@@ -10,7 +10,8 @@
 #include "boards/pico_ice.h"
 
 void ice_fpga_comm_init(void);
+void ice_fpga_comm_wait(void);
 void ice_fpga_comm_write(uint32_t dest_addr, const void* src, uint32_t size);
-void ice_fpga_comm_read_(void* dest, uint32_t src_addr, uint32_t size);
+void ice_fpga_comm_read(void* dest, uint32_t src_addr, uint32_t size);
 
 #endif

--- a/include/ice/init.h
+++ b/include/ice/init.h
@@ -1,0 +1,14 @@
+/** Initialize the board, including USB, but ice_usb_task() should still be called in the main loop.
+* \defgroup init
+*/
+
+#ifndef ICE_INIT_H
+#define ICE_INIT_H
+
+#include <stdint.h>
+#include <assert.h>
+#include "bsp/board.h"
+
+void ice_init_sdk(void);
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,33 @@
+#include "ice/init.h"
+#include "ice/usb.h"
+#include "ice/flash.h"
+#include "ice/fpga.h"
+#include "hardware/gpio.h"
+#include "hardware/uart.h"
+#include "hardware/spi.h"
+
+static void init_rgb_led(void)
+{
+    gpio_init(ICE_LED_RED_PIN);
+    gpio_init(ICE_LED_GREEN_PIN);
+    gpio_init(ICE_LED_BLUE_PIN);
+    gpio_set_dir(ICE_LED_RED_PIN, GPIO_OUT);
+    gpio_set_dir(ICE_LED_GREEN_PIN, GPIO_OUT);
+    gpio_set_dir(ICE_LED_BLUE_PIN, GPIO_OUT);
+    gpio_put(ICE_LED_RED_PIN, false);
+    gpio_put(ICE_LED_GREEN_PIN, true);
+    gpio_put(ICE_LED_BLUE_PIN, true);
+}
+
+/// Call all functions below with default values.
+/// No need to call any other initialization function when this is called.
+void ice_init(void)
+{
+    init_rgb_led();
+    ice_usb_init();
+    
+    // Do not let the Pico control the FPGA flash so the FPGA is free to boot up
+    ice_flash_deinit();
+
+    ice_fpga_init();
+}


### PR DESCRIPTION
It is not used to sense shared activity on the bus, but rather let us know whether we finished our own writing or not.

This would get the examples to work again.
My previous change breaking this was added too inconsiderately.