### PR TITLE
Make async callback ice_smem_read/write_async parameter

### DIFF
--- a/example/pico-ssram/firmware.c
+++ b/example/pico-ssram/firmware.c
@@ -12,6 +12,13 @@
 #define DATA_LEN 8
 #define START_ADDR 0
 
+static uint8_t write_data[DATA_LEN];
+static uint8_t read_data[DATA_LEN];
+
+void write_callback(void* context) {
+    ice_smem_read_async(ICE_SSRAM_SPI_CS_PIN, read_data, START_ADDR, sizeof(read_data), NULL, NULL);
+}
+
 int main() {
     ice_sdk_init();
     stdio_init_all();
@@ -20,8 +27,6 @@ int main() {
     // Dont let the FPGA on the bus so we get exclusive access
     ice_fpga_halt();
 
-    static uint8_t write_data[DATA_LEN];
-    static uint8_t read_data[DATA_LEN];
     for (uint16_t i = 0; i < DATA_LEN; i++) {
         write_data[i] = i;
     }
@@ -31,9 +36,6 @@ int main() {
 
         // The write callback chains a read sequence immediately after the write sequence from an interrupt handler,
         // without any interaction with the main thread.
-        void write_callback(void* context) {
-            ice_smem_read_async(ICE_SSRAM_SPI_CS_PIN, read_data, START_ADDR, sizeof(read_data), NULL, NULL);
-        }
         ice_smem_write_async(ICE_SSRAM_SPI_CS_PIN, START_ADDR, write_data, sizeof(write_data), write_callback, NULL);
 
         // This doesn't return until both the write operation and the read operation chained after it complete.

--- a/include/ice/smem.h
+++ b/include/ice/smem.h
@@ -12,6 +12,8 @@
 #include <stddef.h>
 #include "boards/pico_ice.h"
 
+// This module is _not_ thread safe.
+
 typedef void (*ice_smem_async_callback_t)(void* context);
 
 // Common interface

--- a/include/ice/smem.h
+++ b/include/ice/smem.h
@@ -12,14 +12,13 @@
 #include <stddef.h>
 #include "boards/pico_ice.h"
 
-typedef void (*ice_smem_async_callback_t)(void);
+typedef void (*ice_smem_async_callback_t)(void* context);
 
 // Common interface
 void ice_smem_init(int bit_rate, int irq /* -1 for synchronous mode */);
 void ice_smem_deinit(void);
 bool ice_smem_is_async_complete(void);
 void ice_smem_await_async_completion(void);
-void ice_smem_set_async_callback(ice_smem_async_callback_t callback);
 
 // Higher level interface
 uint8_t ice_smem_get_status(int cs_pin);
@@ -27,19 +26,32 @@ void ice_smem_erase_chip(int cs_pin);
 void ice_smem_erase_sector(int cs_pin, uint32_t dest_addr);
 void ice_smem_enable_write(int cs_pin, bool enabled);
 void ice_smem_write(int cs_pin, uint32_t dest_addr, const void* src, uint32_t size);
-void ice_smem_write_async(int cs_pin, uint32_t dest_addr, const void* src, uint32_t size);
 void ice_smem_read(int cs_pin, void* dest, uint32_t src_addr, uint32_t size);
-void ice_smem_read_async(int cs_pin, void* dest, uint32_t src_addr, uint32_t size);
 void ice_smem_enable_power(int cs_pin, bool enabled);
+
+void ice_smem_write_async(int cs_pin, uint32_t dest_addr, const void* src, uint32_t size,
+                          ice_smem_async_callback_t callback, void* context);
+
+void ice_smem_read_async(int cs_pin, void* dest, uint32_t src_addr, uint32_t size,
+                          ice_smem_async_callback_t callback, void* context);
 
 // Lower level interface
 void ice_smem_output_command(int cs_pin,
                              const uint8_t* command, uint32_t command_size,
-                             const void* data, uint32_t data_size,
-                             bool async);
+                             const void* data, uint32_t data_size);
+
+void ice_smem_output_command_async(int cs_pin,
+                                   const uint8_t* command, uint32_t command_size,
+                                   const void* data, uint32_t data_size,
+                                   ice_smem_async_callback_t callback, void* context);
+
 void ice_smem_input_command(int cs_pin,
                             const uint8_t* command, uint32_t command_size,
-                            void* data, uint32_t data_size,
-                            bool async);
+                            void* data, uint32_t data_size);
+
+void ice_smem_input_command_async(int cs_pin,
+                                  const uint8_t* command, uint32_t command_size,
+                                  void* data, uint32_t data_size,
+                                  ice_smem_async_callback_t callback, void* context);
 
 #endif


### PR DESCRIPTION
Make smem module thead safe.
Allow RTOS to block during async serial memory operation.
Allow async callback to immediately chain another async op.