### PR TITLE
pico-hello-world example fixes

### DIFF
--- a/example/pico-hello-world/CMakeLists.txt
+++ b/example/pico-hello-world/CMakeLists.txt
@@ -13,4 +13,6 @@ pico_sdk_init()
 add_subdirectory(${PICO_ICE_SDK_PATH}/src pico-ice-sdk)
 add_executable(pico_hello_world firmware.c)
 target_link_libraries(pico_hello_world pico_ice_sdk)
+pico_enable_stdio_usb(pico_hello_world 1) # enable usb output
+pico_enable_stdio_uart(pico_hello_world 1) # enable uart output. This might need to be disabled when pico needs uart communication to ice uart.
 pico_add_extra_outputs(pico_hello_world)

--- a/example/pico-hello-world/README.md
+++ b/example/pico-hello-world/README.md
@@ -9,9 +9,10 @@ cmake ..
 make
 ```
 
-This should produce a `firmware.uf2` file to flash onto the pico-ice RP2040 chip.
+This should produce a `pico_hello_world.uf2` file in the build directory to flash onto the pico-ice RP2040 chip.
 See the [main `README.md`](../../README.md) for how to do this.
 
 Then it will print "hello world" in loop across the USB-UART #0 (`firmware.c`)
+BaudRate = 115200
 
-It will also have all the USB features enabled (flashing a bitfile, forwarding the FPGA UART over USB-UART #1).
+It will also have all the USB features enabled (flashing a bitstream file, forwarding the FPGA UART over USB-UART #1).


### PR DESCRIPTION
-Restore printfs to go out to uart and usb. 
-Added new uf2 filename created.
