### PR TITLE
Changes to allow FGPA to execute code after flashing to ice flash

### DIFF
--- a/example/pico-hello-world/CMakeLists.txt
+++ b/example/pico-hello-world/CMakeLists.txt
@@ -13,4 +13,6 @@ pico_sdk_init()
 add_subdirectory(${PICO_ICE_SDK_PATH}/src pico-ice-sdk)
 add_executable(pico_hello_world firmware.c)
 target_link_libraries(pico_hello_world pico_ice_sdk)
+pico_enable_stdio_usb(pico_hello_world 1) # enable usb output
+pico_enable_stdio_uart(pico_hello_world 0) # enable uart output. This might need to be disabled when pico needs uart communication to ice uart.
 pico_add_extra_outputs(pico_hello_world)

--- a/example/pico-hello-world/firmware.c
+++ b/example/pico-hello-world/firmware.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "pico/stdlib.h"
 #include "pico/stdio.h"
 

--- a/include/boards/pico_ice.h
+++ b/include/boards/pico_ice.h
@@ -104,22 +104,28 @@
 #endif
 
 /** Different than boards/pico.h: same physical location, different GPIO pin. */
+//PICO_PMOD_A1 = 16
 #ifndef PICO_DEFAULT_UART_TX_PIN
-#define PICO_DEFAULT_UART_TX_PIN 12
+#define PICO_DEFAULT_UART_TX_PIN 16 
 #endif
 
+
 /** Different than boards/pico.h: same physical location, different GPIO pin. */
+//PICO_PMOD_A2 = 17
 #ifndef PICO_DEFAULT_UART_RX_PIN
-#define PICO_DEFAULT_UART_RX_PIN 13
+#define PICO_DEFAULT_UART_RX_PIN 17 
 #endif
+
 
 // LED
 
 /** The GPIO25 used by pico-sdk is used for sending the clock over to the FPGA.
  * There are three LED pins (RGB): GPIO22 (red), GPIO23 (green), GPIO24 (blue). */
+/*** Not needed to be set explicitly. As pin 15 (blue led) is shared with pico and FPGA
 #ifndef PICO_DEFAULT_LED_PIN
 #define PICO_DEFAULT_LED_PIN 15
 #endif
+***/
 
 // no PICO_DEFAULT_WS2812_PIN
 
@@ -129,13 +135,17 @@
 #define PICO_DEFAULT_I2C 0
 #endif
 
+//PICO_PMOD_B1 = 20
 #ifndef PICO_DEFAULT_I2C_SDA_PIN
-#define PICO_DEFAULT_I2C_SDA_PIN 12
+#define PICO_DEFAULT_I2C_SDA_PIN 20
 #endif
 
+
+//PICO_PMOD_B1 = 21
 #ifndef PICO_DEFAULT_I2C_SCL_PIN
-#define PICO_DEFAULT_I2C_SCL_PIN 13
+#define PICO_DEFAULT_I2C_SCL_PIN 21
 #endif
+
 
 // SPI
 
@@ -184,8 +194,9 @@
 
 /** Changed from the default pico-board to not enable it at all time (due to the RGB LED driving it up).
  * Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
- * It is the PICO_PMOD_A4 pin. */
-#define PICO_SMPS_MODE_PIN 15
+ * It is the PICO_PMOD_A4 pin(19). */
+#define PICO_SMPS_MODE_PIN 19
+
 
 /** Nearly all RP2040 chips sold on 2022 are B0 or B1 iterations, so B0 features are guaranteed to be supported. */
 #ifndef PICO_RP2040_B0_SUPPORTED

--- a/include/ice_sdk.h
+++ b/include/ice_sdk.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 void ice_sdk_init(void);
+void init_rgb_led(void);
 
 #ifdef __cplusplus
 }

--- a/src/ice_fpga_flash.c
+++ b/src/ice_fpga_flash.c
@@ -142,7 +142,7 @@ void ice_fpga_flash_erase_sector(uint32_t addr) {
 
     assert(addr % ICE_FLASH_PAGE_SIZE == 0);
 
-    ice_fpga_flash_wakeup(); //temo
+    ice_fpga_flash_wakeup();
     ice_fpga_flash_enable_write();
 
     soft_spi_chip_select();

--- a/src/ice_fpga_flash.c
+++ b/src/ice_fpga_flash.c
@@ -84,7 +84,7 @@ void ice_fpga_flash_enable_write(void) {
 
 void ice_fpga_flash_init(void) {
     // Hold the FPGA in reset while flashing so that it does not interfer.
-    ice_fpga_halt();
+    //ice_fpga_halt(); //this was moved outside since this function is called late in the init process in tinuuf2
 
     // Setup the associated GPIO pins except CSN
 
@@ -142,6 +142,7 @@ void ice_fpga_flash_erase_sector(uint32_t addr) {
 
     assert(addr % ICE_FLASH_PAGE_SIZE == 0);
 
+    ice_fpga_flash_wakeup(); //temo
     ice_fpga_flash_enable_write();
 
     soft_spi_chip_select();

--- a/src/ice_sdk.c
+++ b/src/ice_sdk.c
@@ -7,7 +7,7 @@
 #include "ice_fpga.h"
 #include "ice_fpga_flash.h"
 
-static void init_rgb_led(void) {
+void init_rgb_led(void) {
     gpio_init(ICE_LED_RED_PIN);
     gpio_init(ICE_LED_GREEN_PIN);
     gpio_init(ICE_LED_BLUE_PIN);
@@ -20,11 +20,12 @@ static void init_rgb_led(void) {
 }
 
 void ice_sdk_init(void) {
-    init_rgb_led();
+    //init_rgb_led(); //this can be called by the user. Otherwise interferes with FGPA executiong bitstream
     ice_usb_init();
     
     // Do not let the Pico control the FPGA flash so the FPGA is free to boot up
     ice_fpga_flash_deinit();
 
     ice_fpga_init();
+    ice_fpga_reset(); //needed to allow FPGA to start execution
 }


### PR DESCRIPTION
**
Changes to allow FGPA to execute code after flashing to ice flash
***
1) board_flash_init() had halt_fgpa which is called by tinyuf2 after pico-sdk init. This was preventing FPGA to execute code.
2) remove init_rgb_led() from ice_sdk_init. This should be called but the software using the SDK. 
3) ice_fpga_flash_erase_chip is called before writing to the ice flash, without this no data was written.

