### PR TITLE
Add definition for FPGA pins

### DIFF
--- a/include/boards/pico_ice.h
+++ b/include/boards/pico_ice.h
@@ -110,8 +110,8 @@
 #ifndef ICE_FPGA_SPI_CSN_PIN
 #define ICE_FPGA_SPI_CSN_PIN 9
 #endif
-#ifndef ICE_SSRAM_SPI_CS_PIN
-#define ICE_SSRAM_SPI_CS_PIN 14
+#ifndef ICE_SRAM_SPI_CS_PIN
+#define ICE_SRAM_SPI_CS_PIN 14
 #endif
 
 // FLASH
@@ -119,7 +119,11 @@
 #define ICE_FLASH_SIZE_BYTES (4 * 1024 * 1024)
 #endif
 
-// ICE40
+// MISC
+#define ICE_GPOUT_CLOCK_PIN             25
+#define ICE_BUTTON_PIN                  10
+
+// ICE40 FPGA (SYSTEM)
 #ifndef ICE_FPGA_CLOCK_PIN
 #define ICE_FPGA_CLOCK_PIN 24
 #endif
@@ -130,9 +134,182 @@
 #define ICE_FPGA_CRESET_B_PIN 27
 #endif
 
-// GPOUT
-#ifndef ICE_GPOUT_CLOCK_PIN
-#define ICE_GPOUT_CLOCK_PIN 25
-#endif
+// ICE40 FPGA IO (PACKAGE NAMES)
+#define ICE_FPGA_35_PIN                 24
+#define ICE_FPGA_27_PIN                 0
+#define ICE_FPGA_25_PIN                 1
+#define ICE_FPGA_21_PIN                 2
+#define ICE_FPGA_19_PIN                 3
+#define ICE_FPGA_26_PIN                 4
+#define ICE_FPGA_23_PIN                 5
+#define ICE_FPGA_20_PIN                 6
+#define ICE_FPGA_18_PIN                 7
+
+// ICE40 FPGA IO (SILICON DIE NAMES)
+#define ICE_FPGA_IOB_6a                 ICE_FPGA_2_PIN
+#define ICE_FPGA_IOB_9b                 ICE_FPGA_3_PIN
+#define ICE_FPGA_IOB_8a                 ICE_FPGA_4_PIN
+#define ICE_FPGA_IOB_13b                ICE_FPGA_6_PIN
+#define ICE_FPGA_IOB_16a                ICE_FPGA_9_PIN
+#define ICE_FPGA_IOB_18a                ICE_FPGA_10_PIN
+#define ICE_FPGA_IOB_20a                ICE_FPGA_11_PIN
+#define ICE_FPGA_IOB_31b                ICE_FPGA_18_PIN
+#define ICE_FPGA_IOB_29b                ICE_FPGA_19_PIN
+#define ICE_FPGA_IOB_25b                ICE_FPGA_20_PIN
+#define ICE_FPGA_IOT_23b                ICE_FPGA_21_PIN
+#define ICE_FPGA_IOT_37a                ICE_FPGA_23_PIN
+#define ICE_FPGA_IOT_36b                ICE_FPGA_25_PIN
+#define ICE_FPGA_IOT_39a                ICE_FPGA_26_PIN
+#define ICE_FPGA_IOT_38b                ICE_FPGA_27_PIN
+#define ICE_FPGA_IOT_41a                ICE_FPGA_28_PIN
+#define ICE_FPGA_IOT_42b                ICE_FPGA_31_PIN
+#define ICE_FPGA_IOT_43a                ICE_FPGA_32_PIN
+#define ICE_FPGA_IOT_44b                ICE_FPGA_34_PIN
+#define ICE_FPGA_IOT_46b                ICE_FPGA_35_PIN
+#define ICE_FPGA_IOT_48b                ICE_FPGA_36_PIN
+#define ICE_FPGA_IOT_50b                ICE_FPGA_38_PIN
+#define ICE_FPGA_IOT_51a                ICE_FPGA_42_PIN
+#define ICE_FPGA_IOT_49a                ICE_FPGA_43_PIN
+#define ICE_FPGA_IOB_3b                 ICE_FPGA_44_PIN
+#define ICE_FPGA_IOB_5b                 ICE_FPGA_45_PIN
+#define ICE_FPGA_IOB_0a                 ICE_FPGA_46_PIN
+#define ICE_FPGA_IOB_2b                 ICE_FPGA_47_PIN
+#define ICE_FPGA_IOB_4a                 ICE_FPGA_48_PIN
+#define ICE_FPGA_IOB_22a                ICE_FPGA_12_PIN
+#define ICE_FPGA_IOB_24a                ICE_FPGA_13_PIN
+#define ICE_FPGA_IOB_18a                ICE_FPGA_10_PIN
+#define ICE_FPGA_IOB_32a                ICE_FPGA_14_PIN
+#define ICE_FPGA_IOB_33b                ICE_FPGA_17_PIN
+#define ICE_FPGA_IOB_34a                ICE_FPGA_15_PIN
+#define ICE_FPGA_IOB_35b                ICE_FPGA_16_PIN
+#define ICE_FPGA_IOT_45a                ICE_FPGA_37_PIN
+
+// ICE_PMOD2A (near LED, shared with iCE40) top row
+// GPIO
+#define ICE_PMOD2A_IO4                  ICE_FPGA_19_PIN
+#define ICE_PMOD2A_IO3                  ICE_FPGA_21_PIN
+#define ICE_PMOD2A_IO2                  ICE_FPGA_25_PIN
+#define ICE_PMOD2A_IO1                  ICE_FPGA_27_PIN
+// I2C
+#define ICE_PMOD2A_SDA                  ICE_PMOD2A_IO4
+#define ICE_PMOD2A_SCL                  ICE_PMOD2A_IO3
+#define ICE_PMOD2A_RST                  ICE_PMOD2A_IO2
+#define ICE_PMOD2A_INT                  ICE_PMOD2A_IO1
+// I2S
+#define ICE_PMOD2A_BCLK                 ICE_PMOD2A_IO4
+#define ICE_PMOD2A_ADC                  ICE_PMOD2A_IO3
+#define ICE_PMOD2A_DAC                  ICE_PMOD2A_IO2
+#define ICE_PMOD2A_LRCLK                ICE_PMOD2A_IO1
+// SPI
+#define ICE_PMOD2A_SCK                  ICE_PMOD2A_IO4
+#define ICE_PMOD2A_MISO                 ICE_PMOD2A_IO3
+#define ICE_PMOD2A_MOSI                 ICE_PMOD2A_IO2
+#define ICE_PMOD2A_CS                   ICE_PMOD2A_IO1
+// UART
+#define ICE_PMOD2A_RTS                  ICE_PMOD2A_IO4
+#define ICE_PMOD2A_RXD                  ICE_PMOD2A_IO3
+#define ICE_PMOD2A_TXD                  ICE_PMOD2A_IO2
+#define ICE_PMOD2A_CTS                  ICE_PMOD2A_IO1
+// HBridge
+#define ICE_PMOD2A_SB                   ICE_PMOD2A_IO4
+#define ICE_PMOD2A_SA                   ICE_PMOD2A_IO3
+#define ICE_PMOD2A_EN                   ICE_PMOD2A_IO2
+#define ICE_PMOD2A_DIR                  ICE_PMOD2A_IO1
+
+// ICE_PMOD2B (near LED, shared with iCE40) bottom row
+// GPIO
+#define ICE_PMOD2B_IO4                  ICE_FPGA_18_PIN
+#define ICE_PMOD2B_IO3                  ICE_FPGA_20_PIN
+#define ICE_PMOD2B_IO2                  ICE_FPGA_23_PIN
+#define ICE_PMOD2B_IO1                  ICE_FPGA_26_PIN
+// I2C
+#define ICE_PMOD2B_SDA                  ICE_PMOD2B_IO4
+#define ICE_PMOD2B_SCL                  ICE_PMOD2B_IO3
+#define ICE_PMOD2B_RST                  ICE_PMOD2B_IO2
+#define ICE_PMOD2B_INT                  ICE_PMOD2B_IO1
+// I2S
+#define ICE_PMOD2B_BCLK                 ICE_PMOD2B_IO4
+#define ICE_PMOD2B_ADC                  ICE_PMOD2B_IO3
+#define ICE_PMOD2B_DAC                  ICE_PMOD2B_IO2
+#define ICE_PMOD2B_LRCLK                ICE_PMOD2B_IO1
+// SPI
+#define ICE_PMOD2B_SCK                  ICE_PMOD2B_IO4
+#define ICE_PMOD2B_MISO                 ICE_PMOD2B_IO3
+#define ICE_PMOD2B_MOSI                 ICE_PMOD2B_IO2
+#define ICE_PMOD2B_CS                   ICE_PMOD2B_IO1
+// UART
+#define ICE_PMOD2B_RTS                  ICE_PMOD2B_IO4
+#define ICE_PMOD2B_RXD                  ICE_PMOD2B_IO3
+#define ICE_PMOD2B_TXD                  ICE_PMOD2B_IO2
+#define ICE_PMOD2B_CTS                  ICE_PMOD2B_IO1
+// HBridge
+#define ICE_PMOD2B_SB                   ICE_PMOD2B_IO4
+#define ICE_PMOD2B_SA                   ICE_PMOD2B_IO3
+#define ICE_PMOD2B_EN                   ICE_PMOD2B_IO2
+#define ICE_PMOD2B_DIR                  ICE_PMOD2B_IO1
+
+// ICE_PMOD3B (near USB) top row
+// GPIO
+#define ICE_PMOD3A_IO4                  19
+#define ICE_PMOD3A_IO3                  18
+#define ICE_PMOD3A_IO2                  17
+#define ICE_PMOD3A_IO1                  16
+// I2C
+#define ICE_PMOD3B_SDA                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_SCL                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_RST                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_INT                  ICE_PMOD3B_IO1
+// I2S
+#define ICE_PMOD3B_BCLK                 ICE_PMOD3B_IO4
+#define ICE_PMOD3B_ADC                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_DAC                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_LRCLK                ICE_PMOD3B_IO1
+// SPI
+#define ICE_PMOD3B_SCK                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_MISO                 ICE_PMOD3B_IO3
+#define ICE_PMOD3B_MOSI                 ICE_PMOD3B_IO2
+#define ICE_PMOD3B_CS                   ICE_PMOD3B_IO1
+// UART
+#define ICE_PMOD3B_RTS                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_RXD                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_TXD                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_CTS                  ICE_PMOD3B_IO1
+// HBridge
+#define ICE_PMOD3B_SB                   ICE_PMOD3B_IO4
+#define ICE_PMOD3B_SA                   ICE_PMOD3B_IO3
+#define ICE_PMOD3B_EN                   ICE_PMOD3B_IO2
+#define ICE_PMOD3B_DIR                  ICE_PMOD3B_IO1
+
+// ICE_PMOD3B (near USB) bottom row
+// GPIO
+#define ICE_PMOD3B_IO4                  23
+#define ICE_PMOD3B_IO3                  22
+#define ICE_PMOD3B_IO2                  21
+#define ICE_PMOD3B_IO1                  20
+// I2C
+#define ICE_PMOD3B_SDA                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_SCL                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_RST                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_INT                  ICE_PMOD3B_IO1
+// I2S
+#define ICE_PMOD3B_BCLK                 ICE_PMOD3B_IO4
+#define ICE_PMOD3B_ADC                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_DAC                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_LRCLK                ICE_PMOD3B_IO1
+// SPI
+#define ICE_PMOD3B_SCK                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_MISO                 ICE_PMOD3B_IO3
+#define ICE_PMOD3B_MOSI                 ICE_PMOD3B_IO2
+#define ICE_PMOD3B_CS                   ICE_PMOD3B_IO1
+// UART
+#define ICE_PMOD3B_RTS                  ICE_PMOD3B_IO4
+#define ICE_PMOD3B_RXD                  ICE_PMOD3B_IO3
+#define ICE_PMOD3B_TXD                  ICE_PMOD3B_IO2
+#define ICE_PMOD3B_CTS                  ICE_PMOD3B_IO1
+// HBridge
+#define ICE_PMOD3B_SB                   ICE_PMOD3B_IO4
+#define ICE_PMOD3B_SA                   ICE_PMOD3B_IO3
+#define ICE_PMOD3B_EN                   ICE_PMOD3B_IO2
+#define ICE_PMOD3B_DIR                  ICE_PMOD3B_IO1
 
 #endif

--- a/include/boards/pico_ice.h
+++ b/include/boards/pico_ice.h
@@ -146,170 +146,170 @@
 #define ICE_FPGA_18_PIN                 7
 
 // ICE40 FPGA IO (SILICON DIE NAMES)
-#define ICE_FPGA_IOB_6a                 ICE_FPGA_2_PIN
-#define ICE_FPGA_IOB_9b                 ICE_FPGA_3_PIN
-#define ICE_FPGA_IOB_8a                 ICE_FPGA_4_PIN
-#define ICE_FPGA_IOB_13b                ICE_FPGA_6_PIN
-#define ICE_FPGA_IOB_16a                ICE_FPGA_9_PIN
-#define ICE_FPGA_IOB_18a                ICE_FPGA_10_PIN
-#define ICE_FPGA_IOB_20a                ICE_FPGA_11_PIN
-#define ICE_FPGA_IOB_31b                ICE_FPGA_18_PIN
-#define ICE_FPGA_IOB_29b                ICE_FPGA_19_PIN
-#define ICE_FPGA_IOB_25b                ICE_FPGA_20_PIN
-#define ICE_FPGA_IOT_23b                ICE_FPGA_21_PIN
-#define ICE_FPGA_IOT_37a                ICE_FPGA_23_PIN
-#define ICE_FPGA_IOT_36b                ICE_FPGA_25_PIN
-#define ICE_FPGA_IOT_39a                ICE_FPGA_26_PIN
-#define ICE_FPGA_IOT_38b                ICE_FPGA_27_PIN
-#define ICE_FPGA_IOT_41a                ICE_FPGA_28_PIN
-#define ICE_FPGA_IOT_42b                ICE_FPGA_31_PIN
-#define ICE_FPGA_IOT_43a                ICE_FPGA_32_PIN
-#define ICE_FPGA_IOT_44b                ICE_FPGA_34_PIN
-#define ICE_FPGA_IOT_46b                ICE_FPGA_35_PIN
-#define ICE_FPGA_IOT_48b                ICE_FPGA_36_PIN
-#define ICE_FPGA_IOT_50b                ICE_FPGA_38_PIN
-#define ICE_FPGA_IOT_51a                ICE_FPGA_42_PIN
-#define ICE_FPGA_IOT_49a                ICE_FPGA_43_PIN
-#define ICE_FPGA_IOB_3b                 ICE_FPGA_44_PIN
-#define ICE_FPGA_IOB_5b                 ICE_FPGA_45_PIN
-#define ICE_FPGA_IOB_0a                 ICE_FPGA_46_PIN
-#define ICE_FPGA_IOB_2b                 ICE_FPGA_47_PIN
-#define ICE_FPGA_IOB_4a                 ICE_FPGA_48_PIN
-#define ICE_FPGA_IOB_22a                ICE_FPGA_12_PIN
-#define ICE_FPGA_IOB_24a                ICE_FPGA_13_PIN
-#define ICE_FPGA_IOB_18a                ICE_FPGA_10_PIN
-#define ICE_FPGA_IOB_32a                ICE_FPGA_14_PIN
-#define ICE_FPGA_IOB_33b                ICE_FPGA_17_PIN
-#define ICE_FPGA_IOB_34a                ICE_FPGA_15_PIN
-#define ICE_FPGA_IOB_35b                ICE_FPGA_16_PIN
-#define ICE_FPGA_IOT_45a                ICE_FPGA_37_PIN
+#define ICE_FPGA_IOB_6a_PIN             ICE_FPGA_2_PIN
+#define ICE_FPGA_IOB_9b_PIN             ICE_FPGA_3_PIN
+#define ICE_FPGA_IOB_8a_PIN             ICE_FPGA_4_PIN
+#define ICE_FPGA_IOB_13b_PIN            ICE_FPGA_6_PIN
+#define ICE_FPGA_IOB_16a_PIN            ICE_FPGA_9_PIN
+#define ICE_FPGA_IOB_18a_PIN            ICE_FPGA_10_PIN
+#define ICE_FPGA_IOB_20a_PIN            ICE_FPGA_11_PIN
+#define ICE_FPGA_IOB_31b_PIN            ICE_FPGA_18_PIN
+#define ICE_FPGA_IOB_29b_PIN            ICE_FPGA_19_PIN
+#define ICE_FPGA_IOB_25b_PIN            ICE_FPGA_20_PIN
+#define ICE_FPGA_IOT_23b_PIN            ICE_FPGA_21_PIN
+#define ICE_FPGA_IOT_37a_PIN            ICE_FPGA_23_PIN
+#define ICE_FPGA_IOT_36b_PIN            ICE_FPGA_25_PIN
+#define ICE_FPGA_IOT_39a_PIN            ICE_FPGA_26_PIN
+#define ICE_FPGA_IOT_38b_PIN            ICE_FPGA_27_PIN
+#define ICE_FPGA_IOT_41a_PIN            ICE_FPGA_28_PIN
+#define ICE_FPGA_IOT_42b_PIN            ICE_FPGA_31_PIN
+#define ICE_FPGA_IOT_43a_PIN            ICE_FPGA_32_PIN
+#define ICE_FPGA_IOT_44b_PIN            ICE_FPGA_34_PIN
+#define ICE_FPGA_IOT_46b_PIN            ICE_FPGA_35_PIN
+#define ICE_FPGA_IOT_48b_PIN            ICE_FPGA_36_PIN
+#define ICE_FPGA_IOT_50b_PIN            ICE_FPGA_38_PIN
+#define ICE_FPGA_IOT_51a_PIN            ICE_FPGA_42_PIN
+#define ICE_FPGA_IOT_49a_PIN            ICE_FPGA_43_PIN
+#define ICE_FPGA_IOB_3b_PIN             ICE_FPGA_44_PIN
+#define ICE_FPGA_IOB_5b_PIN             ICE_FPGA_45_PIN
+#define ICE_FPGA_IOB_0a_PIN             ICE_FPGA_46_PIN
+#define ICE_FPGA_IOB_2b_PIN             ICE_FPGA_47_PIN
+#define ICE_FPGA_IOB_4a_PIN             ICE_FPGA_48_PIN
+#define ICE_FPGA_IOB_22a_PIN            ICE_FPGA_12_PIN
+#define ICE_FPGA_IOB_24a_PIN            ICE_FPGA_13_PIN
+#define ICE_FPGA_IOB_18a_PIN            ICE_FPGA_10_PIN
+#define ICE_FPGA_IOB_32a_PIN            ICE_FPGA_14_PIN
+#define ICE_FPGA_IOB_33b_PIN            ICE_FPGA_17_PIN
+#define ICE_FPGA_IOB_34a_PIN            ICE_FPGA_15_PIN
+#define ICE_FPGA_IOB_35b_PIN            ICE_FPGA_16_PIN
+#define ICE_FPGA_IOT_45a_PIN            ICE_FPGA_37_PIN
 
 // ICE_PMOD2A (near LED, shared with iCE40) top row
 // GPIO
-#define ICE_PMOD2A_IO4                  ICE_FPGA_19_PIN
-#define ICE_PMOD2A_IO3                  ICE_FPGA_21_PIN
-#define ICE_PMOD2A_IO2                  ICE_FPGA_25_PIN
-#define ICE_PMOD2A_IO1                  ICE_FPGA_27_PIN
+#define ICE_PMOD2A_IO4_PIN              ICE_FPGA_19_PIN
+#define ICE_PMOD2A_IO3_PIN              ICE_FPGA_21_PIN
+#define ICE_PMOD2A_IO2_PIN              ICE_FPGA_25_PIN
+#define ICE_PMOD2A_IO1_PIN              ICE_FPGA_27_PIN
 // I2C
-#define ICE_PMOD2A_SDA                  ICE_PMOD2A_IO4
-#define ICE_PMOD2A_SCL                  ICE_PMOD2A_IO3
-#define ICE_PMOD2A_RST                  ICE_PMOD2A_IO2
-#define ICE_PMOD2A_INT                  ICE_PMOD2A_IO1
+#define ICE_PMOD2A_I2C_SDA_PIN          ICE_PMOD2A_IO4_PIN
+#define ICE_PMOD2A_I2C_SCL_PIN          ICE_PMOD2A_IO3_PIN
+#define ICE_PMOD2A_I2C_RST_PIN          ICE_PMOD2A_IO2_PIN
+#define ICE_PMOD2A_I2C_INT_PIN          ICE_PMOD2A_IO1_PIN
 // I2S
-#define ICE_PMOD2A_BCLK                 ICE_PMOD2A_IO4
-#define ICE_PMOD2A_ADC                  ICE_PMOD2A_IO3
-#define ICE_PMOD2A_DAC                  ICE_PMOD2A_IO2
-#define ICE_PMOD2A_LRCLK                ICE_PMOD2A_IO1
+#define ICE_PMOD2A_I2S_BCLK_PIN         ICE_PMOD2A_IO4_PIN
+#define ICE_PMOD2A_I2S_ADC_PIN          ICE_PMOD2A_IO3_PIN
+#define ICE_PMOD2A_I2S_DAC_PIN          ICE_PMOD2A_IO2_PIN
+#define ICE_PMOD2A_I2S_LRCLK_PIN        ICE_PMOD2A_IO1_PIN
 // SPI
-#define ICE_PMOD2A_SCK                  ICE_PMOD2A_IO4
-#define ICE_PMOD2A_MISO                 ICE_PMOD2A_IO3
-#define ICE_PMOD2A_MOSI                 ICE_PMOD2A_IO2
-#define ICE_PMOD2A_CS                   ICE_PMOD2A_IO1
+#define ICE_PMOD2A_SPI_SCK_PIN          ICE_PMOD2A_IO4_PIN
+#define ICE_PMOD2A_SPI_MISO_PIN         ICE_PMOD2A_IO3_PIN
+#define ICE_PMOD2A_SPI_MOSI_PIN         ICE_PMOD2A_IO2_PIN
+#define ICE_PMOD2A_SPI_CS_PIN           ICE_PMOD2A_IO1_PIN
 // UART
-#define ICE_PMOD2A_RTS                  ICE_PMOD2A_IO4
-#define ICE_PMOD2A_RXD                  ICE_PMOD2A_IO3
-#define ICE_PMOD2A_TXD                  ICE_PMOD2A_IO2
-#define ICE_PMOD2A_CTS                  ICE_PMOD2A_IO1
+#define ICE_PMOD2A_UART_RTS_PIN         ICE_PMOD2A_IO4_PIN
+#define ICE_PMOD2A_UART_RXD_PIN         ICE_PMOD2A_IO3_PIN
+#define ICE_PMOD2A_UART_TXD_PIN         ICE_PMOD2A_IO2_PIN
+#define ICE_PMOD2A_UART_CTS_PIN         ICE_PMOD2A_IO1_PIN
 // HBridge
-#define ICE_PMOD2A_SB                   ICE_PMOD2A_IO4
-#define ICE_PMOD2A_SA                   ICE_PMOD2A_IO3
-#define ICE_PMOD2A_EN                   ICE_PMOD2A_IO2
-#define ICE_PMOD2A_DIR                  ICE_PMOD2A_IO1
+#define ICE_PMOD2A_HBRIDGE_SB_PIN       ICE_PMOD2A_IO4_PIN
+#define ICE_PMOD2A_HBRIDGE_SA_PIN       ICE_PMOD2A_IO3_PIN
+#define ICE_PMOD2A_HBRIDGE_EN_PIN       ICE_PMOD2A_IO2_PIN
+#define ICE_PMOD2A_HBRIDGE_DIR_PIN      ICE_PMOD2A_IO1_PIN
 
 // ICE_PMOD2B (near LED, shared with iCE40) bottom row
 // GPIO
-#define ICE_PMOD2B_IO4                  ICE_FPGA_18_PIN
-#define ICE_PMOD2B_IO3                  ICE_FPGA_20_PIN
-#define ICE_PMOD2B_IO2                  ICE_FPGA_23_PIN
-#define ICE_PMOD2B_IO1                  ICE_FPGA_26_PIN
+#define ICE_PMOD2B_IO4_PIN              ICE_FPGA_18_PIN
+#define ICE_PMOD2B_IO3_PIN              ICE_FPGA_20_PIN
+#define ICE_PMOD2B_IO2_PIN              ICE_FPGA_23_PIN
+#define ICE_PMOD2B_IO1_PIN              ICE_FPGA_26_PIN
 // I2C
-#define ICE_PMOD2B_SDA                  ICE_PMOD2B_IO4
-#define ICE_PMOD2B_SCL                  ICE_PMOD2B_IO3
-#define ICE_PMOD2B_RST                  ICE_PMOD2B_IO2
-#define ICE_PMOD2B_INT                  ICE_PMOD2B_IO1
+#define ICE_PMOD2B_I2C_SDA_PIN          ICE_PMOD2B_IO4_PIN
+#define ICE_PMOD2B_I2C_SCL_PIN          ICE_PMOD2B_IO3_PIN
+#define ICE_PMOD2B_I2C_RST_PIN          ICE_PMOD2B_IO2_PIN
+#define ICE_PMOD2B_I2C_INT_PIN          ICE_PMOD2B_IO1_PIN
 // I2S
-#define ICE_PMOD2B_BCLK                 ICE_PMOD2B_IO4
-#define ICE_PMOD2B_ADC                  ICE_PMOD2B_IO3
-#define ICE_PMOD2B_DAC                  ICE_PMOD2B_IO2
-#define ICE_PMOD2B_LRCLK                ICE_PMOD2B_IO1
+#define ICE_PMOD2B_I2S_BCLK_PIN         ICE_PMOD2B_IO4_PIN
+#define ICE_PMOD2B_I2S_ADC_PIN          ICE_PMOD2B_IO3_PIN
+#define ICE_PMOD2B_I2S_DAC_PIN          ICE_PMOD2B_IO2_PIN
+#define ICE_PMOD2B_I2S_LRCLK_PIN        ICE_PMOD2B_IO1_PIN
 // SPI
-#define ICE_PMOD2B_SCK                  ICE_PMOD2B_IO4
-#define ICE_PMOD2B_MISO                 ICE_PMOD2B_IO3
-#define ICE_PMOD2B_MOSI                 ICE_PMOD2B_IO2
-#define ICE_PMOD2B_CS                   ICE_PMOD2B_IO1
+#define ICE_PMOD2B_SPI_SCK_PIN          ICE_PMOD2B_IO4_PIN
+#define ICE_PMOD2B_SPI_MISO_PIN         ICE_PMOD2B_IO3_PIN
+#define ICE_PMOD2B_SPI_MOSI_PIN         ICE_PMOD2B_IO2_PIN
+#define ICE_PMOD2B_SPI_CS_PIN           ICE_PMOD2B_IO1_PIN
 // UART
-#define ICE_PMOD2B_RTS                  ICE_PMOD2B_IO4
-#define ICE_PMOD2B_RXD                  ICE_PMOD2B_IO3
-#define ICE_PMOD2B_TXD                  ICE_PMOD2B_IO2
-#define ICE_PMOD2B_CTS                  ICE_PMOD2B_IO1
+#define ICE_PMOD2B_UART_RTS_PIN         ICE_PMOD2B_IO4_PIN
+#define ICE_PMOD2B_UART_RXD_PIN         ICE_PMOD2B_IO3_PIN
+#define ICE_PMOD2B_UART_TXD_PIN         ICE_PMOD2B_IO2_PIN
+#define ICE_PMOD2B_UART_CTS_PIN         ICE_PMOD2B_IO1_PIN
 // HBridge
-#define ICE_PMOD2B_SB                   ICE_PMOD2B_IO4
-#define ICE_PMOD2B_SA                   ICE_PMOD2B_IO3
-#define ICE_PMOD2B_EN                   ICE_PMOD2B_IO2
-#define ICE_PMOD2B_DIR                  ICE_PMOD2B_IO1
+#define ICE_PMOD2B_HBRIDGE_SB_PIN       ICE_PMOD2B_IO4_PIN
+#define ICE_PMOD2B_HBRIDGE_SA_PIN       ICE_PMOD2B_IO3_PIN
+#define ICE_PMOD2B_HBRIDGE_EN_PIN       ICE_PMOD2B_IO2_PIN
+#define ICE_PMOD2B_HBRIDGE_DIR_PIN      ICE_PMOD2B_IO1_PIN
 
 // ICE_PMOD3B (near USB) top row
 // GPIO
-#define ICE_PMOD3A_IO4                  19
-#define ICE_PMOD3A_IO3                  18
-#define ICE_PMOD3A_IO2                  17
-#define ICE_PMOD3A_IO1                  16
+#define ICE_PMOD3A_IO4_PIN              19
+#define ICE_PMOD3A_IO3_PIN              18
+#define ICE_PMOD3A_IO2_PIN              17
+#define ICE_PMOD3A_IO1_PIN              16
 // I2C
-#define ICE_PMOD3B_SDA                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_SCL                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_RST                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_INT                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_I2C_SDA_PIN          ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_I2C_SCL_PIN          ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_I2C_RST_PIN          ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_I2C_INT_PIN          ICE_PMOD3B_IO1_PIN
 // I2S
-#define ICE_PMOD3B_BCLK                 ICE_PMOD3B_IO4
-#define ICE_PMOD3B_ADC                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_DAC                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_LRCLK                ICE_PMOD3B_IO1
+#define ICE_PMOD3B_I2S_BCLK_PIN         ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_I2S_ADC_PIN          ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_I2S_DAC_PIN          ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_I2S_LRCLK_PIN        ICE_PMOD3B_IO1_PIN
 // SPI
-#define ICE_PMOD3B_SCK                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_MISO                 ICE_PMOD3B_IO3
-#define ICE_PMOD3B_MOSI                 ICE_PMOD3B_IO2
-#define ICE_PMOD3B_CS                   ICE_PMOD3B_IO1
+#define ICE_PMOD3B_SPI_SCK_PIN          ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_SPI_MISO_PIN         ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_SPI_MOSI_PIN         ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_SPI_CS_PIN           ICE_PMOD3B_IO1_PIN
 // UART
-#define ICE_PMOD3B_RTS                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_RXD                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_TXD                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_CTS                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_UART_RTS_PIN         ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_UART_RXD_PIN         ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_UART_TXD_PIN         ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_UART_CTS_PIN         ICE_PMOD3B_IO1_PIN
 // HBridge
-#define ICE_PMOD3B_SB                   ICE_PMOD3B_IO4
-#define ICE_PMOD3B_SA                   ICE_PMOD3B_IO3
-#define ICE_PMOD3B_EN                   ICE_PMOD3B_IO2
-#define ICE_PMOD3B_DIR                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_HBRIDGE_SB_PIN       ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_HBRIDGE_SA_PIN       ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_HBRIDGE_EN_PIN       ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_HBRIDGE_DIR_PIN      ICE_PMOD3B_IO1_PIN
 
 // ICE_PMOD3B (near USB) bottom row
 // GPIO
-#define ICE_PMOD3B_IO4                  23
-#define ICE_PMOD3B_IO3                  22
-#define ICE_PMOD3B_IO2                  21
-#define ICE_PMOD3B_IO1                  20
+#define ICE_PMOD3B_IO4_PIN              23
+#define ICE_PMOD3B_IO3_PIN              22
+#define ICE_PMOD3B_IO2_PIN              21
+#define ICE_PMOD3B_IO1_PIN              20
 // I2C
-#define ICE_PMOD3B_SDA                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_SCL                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_RST                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_INT                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_I2C_SDA_PIN          ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_I2C_SCL_PIN          ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_I2C_RST_PIN          ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_I2C_INT_PIN          ICE_PMOD3B_IO1_PIN
 // I2S
-#define ICE_PMOD3B_BCLK                 ICE_PMOD3B_IO4
-#define ICE_PMOD3B_ADC                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_DAC                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_LRCLK                ICE_PMOD3B_IO1
+#define ICE_PMOD3B_I2S_BCLK_PIN         ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_I2S_ADC_PIN          ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_I2S_DAC_PIN          ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_I2S_LRCLK_PIN        ICE_PMOD3B_IO1_PIN
 // SPI
-#define ICE_PMOD3B_SCK                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_MISO                 ICE_PMOD3B_IO3
-#define ICE_PMOD3B_MOSI                 ICE_PMOD3B_IO2
-#define ICE_PMOD3B_CS                   ICE_PMOD3B_IO1
+#define ICE_PMOD3B_SPI_SCK_PIN          ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_SPI_MISO_PIN         ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_SPI_MOSI_PIN         ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_SPI_CS_PIN           ICE_PMOD3B_IO1_PIN
 // UART
-#define ICE_PMOD3B_RTS                  ICE_PMOD3B_IO4
-#define ICE_PMOD3B_RXD                  ICE_PMOD3B_IO3
-#define ICE_PMOD3B_TXD                  ICE_PMOD3B_IO2
-#define ICE_PMOD3B_CTS                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_UART_RTS_PIN         ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_UART_RXD_PIN         ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_UART_TXD_PIN         ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_UART_CTS_PIN         ICE_PMOD3B_IO1_PIN
 // HBridge
-#define ICE_PMOD3B_SB                   ICE_PMOD3B_IO4
-#define ICE_PMOD3B_SA                   ICE_PMOD3B_IO3
-#define ICE_PMOD3B_EN                   ICE_PMOD3B_IO2
-#define ICE_PMOD3B_DIR                  ICE_PMOD3B_IO1
+#define ICE_PMOD3B_HBRIDGE_SB_PIN       ICE_PMOD3B_IO4_PIN
+#define ICE_PMOD3B_HBRIDGE_SA_PIN       ICE_PMOD3B_IO3_PIN
+#define ICE_PMOD3B_HBRIDGE_EN_PIN       ICE_PMOD3B_IO2_PIN
+#define ICE_PMOD3B_HBRIDGE_DIR_PIN      ICE_PMOD3B_IO1_PIN
 
 #endif

--- a/template/main.c
+++ b/template/main.c
@@ -2,10 +2,15 @@
 #include "pico/stdio.h"
 #include "boards/pico_ice.h"
 #include "ice_usb.h"
+#include "ice_fpga.h"
+#include "ice_led.h"
 
 int main(void) {
     stdio_init_all();
     tusb_init();
+
+    // Release the LED bus
+    ice_led_init();
 
     // Let the FPGA start and give it a clock
     ice_fpga_init(48);


### PR DESCRIPTION
This allows communication between the RP2040 iCE40 as well as with PMODs.

The pins of the two PMODs will soon be updated to allow hardware SPI with the Digilent standard pinout.

In the meantime, these would have to be bit-banged.