### PR TITLE
[WIP] Merge ice_spi.h, ice_smem.h, ice_flash.h, ice_sram.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(pico_ice_sdk INTERFACE
 target_link_libraries(pico_ice_sdk INTERFACE
     hardware_flash
     hardware_gpio
+    hardware_dma
     hardware_pio
     hardware_spi
     hardware_uart

--- a/examples/pico_cram/main.c
+++ b/examples/pico_cram/main.c
@@ -28,12 +28,10 @@
 #include "ice_cram.h"
 #include "ice_fpga.h"
 #include "ice_led.h"
-#include "ice_spi.h"
 #include "rgb_blink.h"
 
 int main(void) {
     ice_led_init();
-    ice_spi_init();
     ice_fpga_init(48);
 
     // Write the whole bitstream to the FPGA CRAM

--- a/examples/pico_flash_io/main.c
+++ b/examples/pico_flash_io/main.c
@@ -53,7 +53,7 @@ int main(void) {
     ice_led_init();
 
     // Booted up, now take control of the Flash
-    ice_spi_init();
+    ice_spi_init(1000000);
     ice_flash_init();
 
     // Write data: known pattern, not very random!

--- a/include/ice_spi.h
+++ b/include/ice_spi.h
@@ -32,11 +32,13 @@
 extern "C" {
 #endif
 
-void ice_spi_init(void);
+#define ICE_SPI_IRQ_NUMBER DMA_IRQ_0
+
+void ice_spi_init(uint baudrate_hz);
 void ice_spi_chip_select(uint8_t csn_pin);
 void ice_spi_chip_deselect(uint8_t csn_pin);
-void ice_spi_write_async(uint8_t const *buf_w, size_t len, void (*callback)(volatile void *), void *context);
-void ice_spi_read_async(uint8_t tx, uint8_t *buf_r, size_t len, void (*callback)(volatile void *), void *context);
+void ice_spi_write_async(const void *data, size_t data_size, void (*callback)(volatile void *), void *context);
+void ice_spi_read_async(uint8_t dummy, uint8_t *data, size_t data_size, void (*callback)(volatile void *), void *context);
 bool ice_spi_is_async_complete(void);
 void ice_spi_await_async_completion(void);
 void ice_spi_read_blocking(uint8_t tx, uint8_t *buf, size_t len);

--- a/src/ice_usb.c
+++ b/src/ice_usb.c
@@ -208,7 +208,7 @@ void tud_dfu_download_cb(uint8_t alt, uint16_t block_num, const uint8_t *data, u
 
         // make sure the RP2040 have full access to the bus
         ice_fpga_stop();
-        ice_spi_init();
+        ice_spi_init(1000000);
 
         if (alt == 0) {
             ice_cram_open();


### PR DESCRIPTION
`ice_spi.h` is only a wrapper to the internal SPI bus, so everything is preconfigured.

Maybe in the future it can be made configurable, but that makes things a bit more complex to handle.

It is still possible to use it to discuss to the FPGA directly, since the CS pin has external control. I.e. it can be 1 pin on the shared PMOD.