### PR TITLE
Use hardware SPI with DMA transfers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(pico_ice_sdk INTERFACE
     hardware_gpio
     hardware_pio
     hardware_spi
+    hardware_dma
     hardware_uart
     pico_stdlib
     )


### PR DESCRIPTION
This change switches ice_spi to use the RP2040 hardware SPI instead of bit banging, and also implements the async transfers that were on the API but unimplemented.