### PR TITLE
SRAM programming over UF2, and flash block erase

### DIFF
--- a/include/boards/pico_ice.h
+++ b/include/boards/pico_ice.h
@@ -95,6 +95,10 @@
 #ifndef ICE_FLASH_SIZE_BYTES
 #define ICE_FLASH_SIZE_BYTES (4 * 1024 * 1024)
 #endif
+// SRAM
+#ifndef ICE_SRAM_SIZE_BYTES
+#define ICE_SRAM_SIZE_BYTES (8 * 1024 * 1024)
+#endif
 // MISC
 #define ICE_GPOUT_CLOCK_PIN 25
 #define ICE_RESET_BUTTON_PIN 28

--- a/include/ice_flash.h
+++ b/include/ice_flash.h
@@ -29,6 +29,7 @@
 
 #define ICE_FLASH_PAGE_SIZE         256
 #define ICE_FLASH_SECTOR_SIZE       4096
+#define ICE_FLASH_BLOCK_SIZE        65536
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +39,7 @@ void ice_flash_init(void);
 void ice_flash_read(uint32_t addr, uint8_t *buf, size_t sz);
 void ice_flash_erase_sector(uint32_t addr);
 void ice_flash_program_page(uint32_t addr, uint8_t const page[ICE_FLASH_PAGE_SIZE]);
+void ice_flash_erase_block(uint32_t addr);
 void ice_flash_erase_chip(void);
 void ice_flash_wakeup(void);
 void ice_flash_sleep(void);

--- a/include/ice_spi.h
+++ b/include/ice_spi.h
@@ -24,6 +24,10 @@
 
 #pragma once
 
+// This is chosen to allow all commands to the flash and SRAM to work.
+// 33MHz is the fastest the SRAM supports a 03h read command.
+#define ICE_SPI_BAUDRATE (33 * 1000 * 1000)
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/include/ice_sram.h
+++ b/include/ice_sram.h
@@ -31,7 +31,10 @@
 // This module is not thread safe.
 
 #define ICE_SRAM_STATUS_BUSY_MASK  0x01
-#define ICE_SRAM_FLASH_PAGE_SIZE   0x100
+
+// Long transfers to/from the SRAM should be avoided as CS should not be
+// asserted for more than 8us.  Holding CS for too long can result in data loss.
+#define ICE_SRAM_TRANSFER_SIZE     32
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ice_flash.c
+++ b/src/ice_flash.c
@@ -40,6 +40,7 @@
 #define FLASH_CMD_ENABLE_WRITE       0x06
 #define FLASH_CMD_STATUS             0x05
 #define FLASH_CMD_SECTOR_ERASE       0x20
+#define FLASH_CMD_BLOCK_ERASE        0xD8
 #define FLASH_CMD_CHIP_ERASE         0xC7
 #define FLASH_CMD_RELEASE_POWERDOWN  0xAB
 #define FLASH_CMD_POWERDOWN          0xB9
@@ -102,6 +103,20 @@ void ice_flash_read(uint32_t addr, uint8_t *buf, size_t sz) {
     ice_spi_write_blocking(cmds, sizeof cmds);
     ice_spi_read_blocking(buf, sz);
     ice_spi_chip_deselect(ICE_FLASH_CSN_PIN);
+}
+
+void ice_flash_erase_block(uint32_t addr) {
+    uint8_t cmds[] = { FLASH_CMD_BLOCK_ERASE, addr >> 16, addr >> 8, addr };
+
+    assert(addr % ICE_FLASH_BLOCK_SIZE == 0);
+
+    ice_flash_enable_write();
+
+    ice_spi_chip_select(ICE_FLASH_CSN_PIN);
+    ice_spi_write_blocking(cmds, sizeof cmds);
+    ice_spi_chip_deselect(ICE_FLASH_CSN_PIN);
+
+    ice_flash_wait();
 }
 
 void ice_flash_erase_chip(void) {

--- a/src/ice_spi.c
+++ b/src/ice_spi.c
@@ -38,6 +38,7 @@ volatile static void (*g_async_callback)(volatile void *);
 volatile static void *g_async_context;
 static int dma_tx, dma_rx;
 static uint32_t dma_word;
+static bool spi_is_initialized;
 
 static void spi_irq_handler(void) {
     if (dma_channel_get_irq1_status(dma_rx)) {
@@ -60,9 +61,15 @@ void ice_spi_init(void) {
     gpio_set_dir(ICE_SPI_TX_PIN, GPIO_IN);
     gpio_set_dir(ICE_SPI_RX_PIN, GPIO_IN);
 
+    if (spi_is_initialized) { 
+        spi_set_baudrate(spi1, ICE_SPI_BAUDRATE);
+        return;
+    }
+    spi_is_initialized = true;
+
     // Initialize SPI, but don't yet assign the pins SPI function so they stay in high impedance mode.
     // Use 33MHz as that is the fastest the SRAM supports a 03h read command.
-    spi_init(spi1, 33 * 1000 * 1000);
+    spi_init(spi1, ICE_SPI_BAUDRATE);
 
     // Setup DMA channel and interrupt handler
     dma_tx = dma_claim_unused_channel(true);

--- a/src/ice_spi.c
+++ b/src/ice_spi.c
@@ -63,6 +63,7 @@ void ice_spi_init(void) {
 
     if (spi_is_initialized) { 
         spi_set_baudrate(spi1, ICE_SPI_BAUDRATE);
+        irq_set_enabled(DMA_IRQ_1, true);
         return;
     }
     spi_is_initialized = true;

--- a/src/ice_sram.c
+++ b/src/ice_sram.c
@@ -79,9 +79,18 @@ void ice_sram_write_async(uint32_t addr, const uint8_t *data, size_t data_size,
 }
 
 void ice_sram_write_blocking(uint32_t addr, const uint8_t *data, size_t data_size) {
-    ice_sram_write_async(addr, data, data_size, NULL, NULL);
-    ice_spi_wait_completion();
-    ice_spi_chip_deselect(ICE_SRAM_CS_PIN);
+    while (data_size) {
+        size_t transfer_size = ICE_SRAM_TRANSFER_SIZE;
+        if (data_size < transfer_size) transfer_size = data_size;
+
+        ice_sram_write_async(addr, data, transfer_size, NULL, NULL);
+        ice_spi_wait_completion();
+        ice_spi_chip_deselect(ICE_SRAM_CS_PIN);
+        
+        data_size -= transfer_size;
+        data += transfer_size;
+        addr += transfer_size;
+    }
 }
 
 void ice_sram_read_async(uint32_t addr, uint8_t *data, size_t data_size,
@@ -94,7 +103,16 @@ void ice_sram_read_async(uint32_t addr, uint8_t *data, size_t data_size,
 }
 
 void ice_sram_read_blocking(uint32_t addr, uint8_t *data, size_t data_size) {
-    ice_sram_read_async(addr, data, data_size, NULL, NULL);
-    ice_spi_wait_completion();
-    ice_spi_chip_deselect(ICE_SRAM_CS_PIN);
+    while (data_size) {
+        size_t transfer_size = ICE_SRAM_TRANSFER_SIZE;
+        if (data_size < transfer_size) transfer_size = data_size;
+
+        ice_sram_read_async(addr, data, transfer_size, NULL, NULL);
+        ice_spi_wait_completion();
+        ice_spi_chip_deselect(ICE_SRAM_CS_PIN);
+        
+        data_size -= transfer_size;
+        data += transfer_size;
+        addr += transfer_size;
+    }
 }

--- a/src/tinyuf2_board.c
+++ b/src/tinyuf2_board.c
@@ -13,31 +13,60 @@
 #include "ice_flash.h"
 #include "ice_fpga.h"
 #include "ice_spi.h"
+#include "ice_sram.h"
 
 static alarm_id_t alarm_id;
 static bool flash_ready;
+static bool sram_ready;
+static uint32_t flash_erased[ICE_FLASH_SIZE_BYTES / (ICE_FLASH_BLOCK_SIZE * 32)];
+
+#define SRAM_ADDR 0x20000000
 
 void board_flash_read(uint32_t addr, void *buffer, uint32_t len)
 {
-    if (!flash_ready) {
-        ice_flash_init();
-        flash_ready = true;
+    if (addr >= SRAM_ADDR) {
+        addr -= SRAM_ADDR;
+        if (!sram_ready) {
+            ice_sram_init();
+            sram_ready = true;
+        }
+        ice_sram_read_blocking(addr, buffer, len);
     }
-    ice_flash_read(addr, buffer, len);
+    else {
+        if (!flash_ready) {
+            ice_flash_init();
+            flash_ready = true;
+        }
+        ice_flash_read(addr, buffer, len);
+    }
 }
 
 void board_flash_write(uint32_t addr, const void *data, uint32_t len)
 {
-    if (!flash_ready) {
-        ice_fpga_stop();
-        ice_flash_init();
-        flash_ready = true;
-        ice_flash_erase_chip();
+    if (addr >= SRAM_ADDR) {
+        addr -= SRAM_ADDR;
+        if (!sram_ready) {
+            ice_sram_init();
+            sram_ready = true;
+        }
+        ice_sram_write_blocking(addr, data, len);
     }
-    if (len != ICE_FLASH_PAGE_SIZE) {
-        printf("%s: expected len=%u got len=%ld\r\n", __func__, ICE_FLASH_PAGE_SIZE, len);
-    } else {
-        ice_flash_program_page(addr, data);
+    else {
+        if (!flash_ready) {
+            ice_fpga_stop();
+            ice_flash_init();
+            flash_ready = true;
+        }
+        int flash_erase_idx = addr / ICE_FLASH_BLOCK_SIZE;
+        if ((flash_erased[flash_erase_idx >> 5] & (1u << (flash_erase_idx & 0x1F))) == 0) {
+            ice_flash_erase_block(addr & ~(ICE_FLASH_BLOCK_SIZE - 1));
+            flash_erased[flash_erase_idx >> 5] |= 1u << (flash_erase_idx & 0x1F);
+        }
+        if (len != ICE_FLASH_PAGE_SIZE) {
+            printf("%s: expected len=%u got len=%ld\r\n", __func__, ICE_FLASH_PAGE_SIZE, len);
+        } else {
+            ice_flash_program_page(addr, data);
+        }
     }
 }
 


### PR DESCRIPTION
This PR exposes the SRAM to UF2 files at address 0x20000000.

Additionally, it adds block erase for the flash, and uses it to make flash programming over UF2 much faster.

I've also limited the length of reads and writes to the SRAM, as it doesn't like very long transactions.