### PR TITLE
Fix flash programming using dfu-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.5.0
+
+* In the USB DFU interface, swap the alt=0 and alt=1 numbers to get APIO and
+  IceStudio to work again out of the box.
+
+* Fix DFU CRAM programming.
+
 ## v1.3.1
 
 * Make USB enumerate better in MacOS and everywhere (@dicristina).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1
+
+* Make USB enumerate better in MacOS and everywhere (@dicristina).
+
 ## v1.3.0
 
 * Switch SPI to hardware back-end with DMA (@MichaelBell).

--- a/README.md
+++ b/README.md
@@ -7,11 +7,4 @@
 | [Assembly](https://htmlpreview.github.io/?https://github.com/tinyvision-ai-inc/pico-ice/blob/main/Board/Rev3/bom/ibom.html)
 | [Discord](https://discord.gg/t2CzbAYeD2)
 
-[![LectronZ](https://lectronz.com/static/badges/buy-it-on-lectronz-medium.png)](https://lectronz.com/stores/tinyvision-ai-store)
-[![Tindie](https://d2ss6ovg47m0r5.cloudfront.net/badges/tindie-smalls.png)](https://www.tindie.com/stores/tinyvision_ai/?ref=offsite_badges&utm_source=sellers_vr2045&utm_medium=badges&utm_campaign=badge_small%22%3E)
-
-This is a library for using the [pico-ice](https://pico-ice.tinyvision.ai/) board.
-
-See the [getting started instructions](https://pico-ice.tinyvision.ai/getting_started.html) for a general introduction.
-
-See the [pico-ice-sdk doc](https://pico-ice.tinyvision.ai/pico_ice_sdk.html) to write custom firmware for the pico-ice.
+This is the SDK for building custom firmware for the RP2040 on the [pico-ice](https://pico-ice.tinyvision.ai/) board.

--- a/examples/pico_blinky_cplusplus/usb_descriptors.c
+++ b/examples/pico_blinky_cplusplus/usb_descriptors.c
@@ -41,6 +41,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_PRODUCT]         = USB_PRODUCT,
     [STRID_SERIAL_NUMBER]   = usb_serial_number,
     [STRID_VENDOR]          = USB_VENDOR,
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/examples/pico_fpga_io/usb_descriptors.c
+++ b/examples/pico_fpga_io/usb_descriptors.c
@@ -41,6 +41,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_PRODUCT]         = USB_PRODUCT,
     [STRID_SERIAL_NUMBER]   = usb_serial_number,
     [STRID_VENDOR]          = USB_VENDOR,
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/examples/pico_usb_fpga/usb_descriptors.c
+++ b/examples/pico_usb_fpga/usb_descriptors.c
@@ -47,6 +47,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_VENDOR]          = USB_VENDOR,
     [STRID_CDC+0]           = "RP2040 logs",
     [STRID_CDC+1]           = "iCE40 UART",
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/examples/pico_usb_spi/usb_descriptors.c
+++ b/examples/pico_usb_spi/usb_descriptors.c
@@ -47,6 +47,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_VENDOR]          = USB_VENDOR,
     [STRID_CDC+0]           = "RP2040 logs",
     [STRID_CDC+1]           = "SPI",
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/examples/pico_usb_uart/usb_descriptors.c
+++ b/examples/pico_usb_uart/usb_descriptors.c
@@ -47,6 +47,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_VENDOR]          = USB_VENDOR,
     [STRID_CDC+0]           = "RP2040 logs",
     [STRID_CDC+1]           = "iCE40 UART",
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/examples/pico_usb_uf2/usb_descriptors.c
+++ b/examples/pico_usb_uf2/usb_descriptors.c
@@ -47,6 +47,6 @@ char const *tud_string_desc[STRID_NUM_TOTAL] = {
     [STRID_VENDOR]          = USB_VENDOR,
     [STRID_CDC+0]           = "RP2040 logs",
     [STRID_MSC+0]           = "iCE40 MSC (Flash)",
-    [STRID_DFU+0]           = "iCE40 DFU (CRAM)",
-    [STRID_DFU+1]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+0]           = "iCE40 DFU (Flash)",
+    [STRID_DFU+1]           = "iCE40 DFU (CRAM)",
 };

--- a/include/ice_cram.h
+++ b/include/ice_cram.h
@@ -64,4 +64,4 @@ bool ice_cram_close(void);
 }
 #endif
 
-./** @} */
+/** @} */

--- a/include/ice_sram.h
+++ b/include/ice_sram.h
@@ -51,7 +51,7 @@ extern "C" {
 /**
  * @brief Send an initialization command to the SRAM chip.
  */
-avoid ice_sram_init(void);
+void ice_sram_init(void);
 
 /**
  * @brief Send a reset command to the SRAM chipo.

--- a/src/ice_cram.c
+++ b/src/ice_cram.c
@@ -33,7 +33,8 @@ static int sm;
 static uint offset;
 static const int clk_div = 1;  // 1Mbit/sec for debugging, could be much faster
 
-static bool try_add_program(PIO try_pio) {
+static bool try_add_program(PIO try_pio)
+{
     if (!pio_can_add_program(try_pio, &ice_cram_program)) {
         return false;
     }
@@ -49,11 +50,12 @@ static bool try_add_program(PIO try_pio) {
     return true;
 }
 
-static void state_machine_init() {
+static void state_machine_init(void)
+{
     // Try to fit the program into either PIO bank
     if (!try_add_program(pio1)) {
         if (!try_add_program(pio0)) {
-            panic("Could not add FPGA configuration PIO program");
+                panic("Could not add FPGA configuration PIO program");
         }
     }
 
@@ -73,7 +75,8 @@ static void state_machine_init() {
     pio_gpio_init(pio, ICE_SPI_SCK_PIN);
 }
 
-static void state_machine_deinit() {
+static void state_machine_deinit(void)
+{
     pio_sm_set_enabled(pio, sm, false);
     pio_sm_set_consecutive_pindirs(pio, sm, ICE_SPI_RX_PIN, 1, false);
     pio_sm_set_consecutive_pindirs(pio, sm, ICE_SPI_SCK_PIN, 1, false);
@@ -87,7 +90,8 @@ static void put_byte(uint8_t data) {
     pio_sm_put_blocking(pio, sm, data << 24);
 }
 
-static void wait_idle() {
+static void wait_idle(void)
+{
     // Wait until the last byte has been pulled from the FIFO.
     while (!pio_sm_is_tx_fifo_empty(pio, sm)) {
         tight_loop_contents();
@@ -103,7 +107,8 @@ static void wait_idle() {
     }
 }
 
-void ice_cram_open(void) {
+void ice_cram_open(void)
+{
     // Hold FPGA in reset before doing anything with SPI bus.
     gpio_put(ICE_FPGA_CRESET_B_PIN, false);
 
@@ -128,13 +133,15 @@ void ice_cram_open(void) {
     gpio_put(ICE_CRAM_CSN_PIN, false);
 }
 
-bool ice_cram_write(const uint8_t* bitstream, uint32_t size) {
+bool ice_cram_write(const uint8_t* bitstream, uint32_t size)
+{
     for (uint32_t i = 0; i < size; ++i) {
         put_byte(bitstream[i]);
     }
 }
 
-bool ice_cram_close(void) {
+bool ice_cram_close(void)
+{
     wait_idle();
 
     // Bring SPI_SS high at end of bitstream and leave it pulled up.

--- a/src/ice_cram.c
+++ b/src/ice_cram.c
@@ -26,6 +26,7 @@
 #include "hardware/pio.h"
 #include "pico/time.h"
 #include "boards/pico_ice.h"
+#include "ice_fpga.h"
 #include "ice_cram.pio.h"
 
 static PIO pio;
@@ -110,11 +111,11 @@ static void wait_idle(void)
 void ice_cram_open(void)
 {
     // Hold FPGA in reset before doing anything with SPI bus.
-    gpio_put(ICE_FPGA_CRESET_B_PIN, false);
+    ice_fpga_stop();
 
     state_machine_init();
 
-    // SPI_SS low signals FPGA to receive bitstream.
+    // SPI_SS low signals FPGA to receive the bitstream.
     gpio_init(ICE_CRAM_CSN_PIN);
     gpio_put(ICE_CRAM_CSN_PIN, false);
     gpio_set_dir(ICE_CRAM_CSN_PIN, GPIO_OUT);

--- a/src/ice_usb.c
+++ b/src/ice_usb.c
@@ -353,8 +353,8 @@ void dfu_init(uint8_t alt)
         // lock, in which case DFU download might hang.
         multicore_reset_core1();
 
-        // Disable all interrupts except USB.
-        irq_set_mask_enabled(~(1 << USBCTRL_IRQ), false);
+        // Disable all interrupts except USB and DMA (needed for flash program)
+        irq_set_mask_enabled(~((1 << USBCTRL_IRQ) | (1 << DMA_IRQ_1)), false);
 
         // Make sure the RP2040 have full access to the SPI bus
         ice_fpga_stop();

--- a/src/ice_usb.c
+++ b/src/ice_usb.c
@@ -343,6 +343,9 @@ void dfu_init(uint8_t alt)
         ice_cram_open();
         break;
     case DFU_ALT_FLASH:
+        // Make sure the RP2040 have full access to the SPI bus
+        ice_fpga_stop();
+
         ice_flash_init();
 
         // Ensure reboot in case user doesn't pass -R to dfu-util
@@ -355,9 +358,6 @@ void dfu_init(uint8_t alt)
 
         // Disable all interrupts except USB and DMA (needed for flash program)
         irq_set_mask_enabled(~((1 << USBCTRL_IRQ) | (1 << DMA_IRQ_1)), false);
-
-        // Make sure the RP2040 have full access to the SPI bus
-        ice_fpga_stop();
         break;
     }
 }

--- a/src/tinyuf2_board.c
+++ b/src/tinyuf2_board.c
@@ -23,17 +23,10 @@ static uint32_t flash_erased[ICE_FLASH_SIZE_BYTES / (ICE_FLASH_BLOCK_SIZE * 32)]
 
 void board_flash_read(uint32_t addr, void *buffer, uint32_t len)
 {
-    if (!spi_ready) {
-        ice_fpga_stop();
-        ice_sram_init();
-        ice_flash_init();
-        spi_ready = true;
-    }
     if (addr >= SRAM_ADDR) {
         addr -= SRAM_ADDR;
         ice_sram_read_blocking(addr, buffer, len);
-    }
-    else {
+    } else {
         ice_flash_read(addr, buffer, len);
     }
 }
@@ -49,8 +42,7 @@ void board_flash_write(uint32_t addr, const void *data, uint32_t len)
     if (addr >= SRAM_ADDR) {
         addr -= SRAM_ADDR;
         ice_sram_write_blocking(addr, data, len);
-    }
-    else {
+    } else {
         int flash_erase_idx = addr / ICE_FLASH_BLOCK_SIZE;
         if ((flash_erased[flash_erase_idx >> 5] & (1u << (flash_erase_idx & 0x1F))) == 0) {
             ice_flash_erase_block(addr & ~(ICE_FLASH_BLOCK_SIZE - 1));


### PR DESCRIPTION
Since commit 2b52c6e (Use hardware SPI and DMA transfer), hardware SPI has been used with hardware DMA to program the ICE40 FPGA SPI flash. This means that in order for SPI transfers to the flash to complete, the DMA interrupt must remain enabled. Keep the DMA interrupt enabled when entering the USB DFU flash programming code, to ensure that SPI flash writes complete.

Without this fix, dfu-util is unable to program the FLASH slot, and can only program to the CRAM slot. This is because the SPI transfer will wait indefinitely to complete (as DMA interrupt is disabled), and the watchdog will reset the RT2040.

*Note*- it looks like the `develop` branch is behind `main`, but the contribution guidelines say to open a pull request there. Please let me know if I should change the base branch this PR targets