### PR TITLE
Hi speed uart rx

### DIFF
--- a/include/ice_usb.h
+++ b/include/ice_usb.h
@@ -197,6 +197,7 @@ extern void (*tud_cdc_rx_cb_table[CFG_TUD_CDC])(uint8_t);
 
 void ice_usb_init(void);
 void ice_usb_sleep_ms(uint32_t ms);
+void ice_usb_task();
 
 #ifdef __cplusplus
 }

--- a/src/ice_usb.c
+++ b/src/ice_usb.c
@@ -97,7 +97,7 @@ char usb_serial_number[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
 void ice_usb_sleep_ms(uint32_t ms)
 {
     while (ms-- > 0) {
-        tud_task();
+        ice_usb_task();
         sleep_ms(1);
     }
 }
@@ -171,7 +171,6 @@ static void ice_usb_uart0_to_cdc(void)
     while (uart_is_readable(uart0)) {
         uint8_t byte = uart_getc(uart0);
         tud_cdc_n_write_char(ICE_USB_UART0_CDC, byte);
-        tud_cdc_n_write_flush(ICE_USB_UART0_CDC);
     }
 }
 
@@ -191,7 +190,6 @@ static void ice_usb_uart1_to_cdc(void)
     while (uart_is_readable(uart1)) {
         uint8_t byte = uart_getc(uart1);
         tud_cdc_n_write_char(ICE_USB_UART1_CDC, byte);
-        tud_cdc_n_write_flush(ICE_USB_UART1_CDC);
     }
 }
 
@@ -487,5 +485,19 @@ void ice_usb_init(void)
 #ifdef ICE_USB_USE_TINYUF2_MSC
     board_init();
     uf2_init();
+#endif
+}
+
+// Task function should be called in main/rtos loop
+// this additionally flushes uart buffers
+void ice_usb_task() {
+    tud_task();
+
+#ifdef ICE_USB_UART0_CDC
+    tud_cdc_n_write_flush(ICE_USB_UART0_CDC);
+#endif
+
+#ifdef ICE_USB_UART1_CDC
+    tud_cdc_n_write_flush(ICE_USB_UART1_CDC);
 #endif
 }


### PR DESCRIPTION
Hi,

I'm trying to implement hi speed uart comms. Commits:
- [moved uart flushes out of interrupts to new function ice_usb_task()](https://github.com/tinyvision-ai-inc/pico-ice-sdk/commit/473e38978f7f8caab7e20c6b49f9f48623158dcf) -- this already gives better results, it "works"
- [[draft] uart1 fifo](https://github.com/tinyvision-ai-inc/pico-ice-sdk/commit/089f5ff43a18760b5cc803d6e53919c1e48deb00) -- this tries to implement basic fifo for uart1, read commit msg for more info

*Required changes to `pico-ice-default`: use `ice_usb_task()` instead of `tud_task()` in main.*

Requesting feedback on this one.

edit: it doesn't introduce any additional latency.