### PR TITLE
Fix workflow caching, disable fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     strategy:
+      fail-fast: false
       matrix:
         cmake_build_type: [Debug, Release]
         example:
@@ -48,6 +49,7 @@ jobs:
             ${{ runner.os }}-build-
 
       - name: Fetch submodules
+        if: steps.cache-submodules.outputs.cache-hit != 'true'
         run: |
           git submodule update --init
           git -C lib/pico-sdk submodule update --init


### PR DESCRIPTION
workflow caching was not working as intended, fail-fast caused fail of all jobs when one build failed.

This should now properly cache submodules and attempts to build all samples regardless of one failure.

