### PR TITLE
Remove use of C23/C++23 #elifdef

### DIFF
--- a/include/boards.h
+++ b/include/boards.h
@@ -26,7 +26,7 @@
 
 #ifdef PICO2_ICE
 #include "boards/pico2_ice.h"
-#elifdef PICO_ICE
+#elif defined(PICO_ICE)
 #include "boards/pico_ice.h"
 #else
 #error "pico-ice board model not found, check the value of PICO_BOARD"


### PR DESCRIPTION
`#elifdef` is a C23/C++23 feature. As C23/C++23 standard is not required by CMakeLists.txt, these features should not be used.