### PR TITLE
Fix typo in ice_led

### DIFF
--- a/src/ice_led.c
+++ b/src/ice_led.c
@@ -56,17 +56,17 @@ void ice_led_red(bool state)
 void ice_led_green(bool state)
 {
     if (state) {
-        ice_hal_gpio_set_0(ICE_LED_RED_PIN);
+        ice_hal_gpio_set_0(ICE_LED_GREEN_PIN);
     } else {
-        ice_hal_gpio_set_high_z(ICE_LED_RED_PIN);
+        ice_hal_gpio_set_high_z(ICE_LED_GREEN_PIN);
     }
 }
 
 void ice_led_blue(bool state)
 {
     if (state) {
-        ice_hal_gpio_set_0(ICE_LED_RED_PIN);
+        ice_hal_gpio_set_0(ICE_LED_BLUE_PIN);
     } else {
-        ice_hal_gpio_set_high_z(ICE_LED_RED_PIN);
+        ice_hal_gpio_set_high_z(ICE_LED_BLUE_PIN);
     }
 }


### PR DESCRIPTION
All of the constants for the led functions were set to toggle RED_LED, this sets the constants correctly

Required:
- Contributions go to `develop` rather than `main` or `master`

Appreciated:
- 4 spaces indents
- `if (...) { single_statement(); }` always with braces
- `function() {` with the brace on the same line
- `//` comments everywhere
- https://www.kernel.org/doc/html/v4.10/process/coding-style.html for the rest
